### PR TITLE
Simplify 'CreateElement', remove potential error in 'AsyncComponent' …

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -19,7 +19,7 @@ interface EsModuleComponent {
 export type AsyncComponent<Data=DefaultData<Vue>, Methods=DefaultMethods<Vue>, Computed=DefaultComputed, Props=DefaultProps> = (
   resolve: (component: Component<Data, Methods, Computed, Props>) => void,
   reject: (reason?: any) => void
-) => Promise<Component | EsModuleComponent> | Component | void;
+) => Promise<Component | EsModuleComponent> | void;
 
 /**
  * When the `Computed` type parameter on `ComponentOptions` is inferred,

--- a/types/test/options-test.ts
+++ b/types/test/options-test.ts
@@ -163,11 +163,6 @@ Vue.component('component', {
 
       createElement(() => Vue.component("component")),
       createElement(() => ( {} as ComponentOptions<Vue> )),
-      createElement(() => {
-        return new Promise((resolve) => {
-          resolve({} as ComponentOptions<Vue>);
-        })
-      }),
       createElement((resolve, reject) => {
         resolve({} as ComponentOptions<Vue>);
         reject();

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -16,12 +16,8 @@ import { VNode, VNodeData, VNodeChildren, ScopedSlot } from "./vnode";
 import { PluginFunction, PluginObject } from "./plugin";
 
 export interface CreateElement {
-  // empty node
-  (): VNode;
-
-  // component constructor or options
-  (tag: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, children: VNodeChildren): VNode;
-  (tag: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, data?: VNodeData, children?: VNodeChildren): VNode;
+  (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, children?: VNodeChildren): VNode;
+  (tag?: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, data?: VNodeData, children?: VNodeChildren): VNode;
 }
 
 export interface Vue {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -19,17 +19,9 @@ export interface CreateElement {
   // empty node
   (): VNode;
 
-  // element or component name
-  (tag: string, children: VNodeChildren): VNode;
-  (tag: string, data?: VNodeData, children?: VNodeChildren): VNode;
-
   // component constructor or options
-  (tag: Component<any, any, any, any>, children: VNodeChildren): VNode;
-  (tag: Component<any, any, any, any>, data?: VNodeData, children?: VNodeChildren): VNode;
-
-  // async component
-  (tag: AsyncComponent<any, any, any, any>, children: VNodeChildren): VNode;
-  (tag: AsyncComponent<any, any, any, any>, data?: VNodeData, children?: VNodeChildren): VNode;
+  (tag: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, children: VNodeChildren): VNode;
+  (tag: string | Component<any, any, any, any> | AsyncComponent<any, any, any, any>, data?: VNodeData, children?: VNodeChildren): VNode;
 }
 
 export interface Vue {


### PR DESCRIPTION
I encountered a few situations where passing in an array of `number` for children caused some sub-optimal error messages because TypeScript falls back to the last overload for error reporting. You end up with something like "`string` is not assignable to `AsyncComponent`" which is misleading. So I simplified the overloads in for `CreateElement`, though this broke a few test cases.

It seemed like the root of the break was that type for `AsyncComponent` was slightly inaccurate, which I corrected, but this broke a *different* test case. I tried it out, and it turns out [that test case actually causes Vue to hang](https://github.com/vuejs/vue/issues/6558), so I've removed it.