### PR TITLE
Use the 'string' primitive type for selectors.

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -64,7 +64,7 @@ export interface ComponentOptions<
   methods?: Methods;
   watch?: Record<string, WatchOptionsWithHandler<any> | WatchHandler<any> | string>;
 
-  el?: Element | String;
+  el?: Element | string;
   template?: string;
   render?(createElement: CreateElement): VNode;
   renderError?: (h: () => VNode, err: Error) => VNode;

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -37,7 +37,7 @@ export interface Vue {
   readonly $attrs: Record<string, string>;
   readonly $listeners: Record<string, Function | Function[]>;
 
-  $mount(elementOrSelector?: Element | String, hydrating?: boolean): this;
+  $mount(elementOrSelector?: Element | string, hydrating?: boolean): this;
   $forceUpdate(): void;
   $destroy(): void;
   $set: typeof Vue.set;


### PR DESCRIPTION
Vue doesn't actually permit anything like:

```ts
new Vue({
  template: "<div>content</div>",
  el: new String("#hero"),
})
```

`el` has to be a primitive `string`.